### PR TITLE
Fix feature overlapping sidebar when dragged or resized.

### DIFF
--- a/www/styles/curate.less
+++ b/www/styles/curate.less
@@ -45,6 +45,8 @@
 
 .sidebar {
   overflow-y: auto;
+  background-color: white;
+  z-index: 10;
 }
 
 .sidebar > h4 {


### PR DESCRIPTION
The overlap is because drag / resize helper is attached to body. While
draggable has an option to attach helper to another element, resizable
doesn't. The only option thus is this hack.

Thanks to Harsh Gupta gupta.harsh96@gmail.com for suggesting z-index.

closes #56.

Signed-off-by: Vivek Rai vivekraiiitkgp@gmail.com
